### PR TITLE
Update mailparser package to the newest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "imap": "~0.3.1",
-        "mailparser": "~0.2.24",
+        "mailparser": "~0.4",
         "seq": "~0.3.5"
     },
     "main": "./index.js",


### PR DESCRIPTION
I've noticed there are some issues with parsing emails when content-type in headers is different than actual text charset. With the newest version of mailparser it works fine.
