### PR TITLE
introduce async to prevent duplicate event

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "git://github.com/jcreigno/nodejs-mail-notifier.git"
   },
   "dependencies": {
+    "async": "^2.5.0",
     "debug": "^2.2.0",
     "imap": "~0.8.9",
     "mailparser": "~0.4"


### PR DESCRIPTION
i've tested successfully this option of introducing 'async', to prevent 2 "search of UNSEEN" at the same time (and so firing 2 times the same event before marking unseen mail)
don't know if this is the best answer, but it works ...